### PR TITLE
[PATCH] Fix NBLOCK parsing in Vasp>=6

### DIFF
--- a/pyiron_vasp/vasp/parser/outcar.py
+++ b/pyiron_vasp/vasp/parser/outcar.py
@@ -692,10 +692,8 @@ class Outcar(object):
         for line in lines:
             if trigger in line:
                 steps += 1
-            if nblock is None and "NBLOCK" in line:
-                line = line.strip()
-                line = _clean_line(line)
-                nblock = int(nblock_regex.findall(line)[0])
+            if nblock is None and (match := nblock_regex.search(line)):
+                nblock = int(match[1])
         if nblock is None:
             nblock = 1
         return np.arange(0, steps * nblock, nblock)


### PR DESCRIPTION
Vasp 5 only prints NBLOCK once and together with KBLOCK, a fact that was assumed when parsing that line.  Newer versions of VASP also print INCAR at the beginning, which causes a spurious match and then makes the parsing regex fail. Now we just use the regex itself to match the line to parse, which eliminates the spurious match.