### PR TITLE
Add and extend docstrings across all parser modules

### DIFF
--- a/src/vaspparser/dft/bader.py
+++ b/src/vaspparser/dft/bader.py
@@ -32,17 +32,23 @@ class Bader:
 
     def __init__(self, structure: Atoms, working_directory: str) -> None:
         """
-        Initialize the Bader module
+        Initialize the Bader module.
 
         Args:
-            job (pyiron_atomistics.dft.job.generic.GenericDFTJob): A DFT job instance (finished/converged job)
+            structure (ase.atoms.Atoms): The atomistic structure of the finished DFT calculation
+            working_directory (str): Path to the directory containing the VASP output files
+                (must contain AECCAR0 and AECCAR2 for total and valence charge densities)
         """
         self._working_directory = working_directory
         self._structure = structure
 
     def _create_cube_files(self) -> None:
         """
-        Create CUBE format files of the total and valce charges to be used by the Bader program
+        Create CUBE format files of the valence and total charge densities for use by the Bader program.
+
+        Reads AECCAR0 (core charge) and AECCAR2 (valence charge) from the working directory,
+        sums them to obtain the total charge density, and writes both the valence charge
+        (``valence_charge.CUBE``) and total charge (``total_charge.CUBE``) to disk.
         """
         cd_val, cd_total = get_valence_and_total_charge_density(
             working_directory=self._working_directory
@@ -139,10 +145,20 @@ def get_valence_and_total_charge_density(
     working_directory: str,
 ) -> Tuple[VaspVolumetricData, VaspVolumetricData]:
     """
-    Gives the valence and total charge densities
+    Read the valence and total all-electron charge densities from AECCAR files.
+
+    VASP writes the core charge density to AECCAR0 and the valence charge density
+    to AECCAR2 when ``LAECHG = .TRUE.`` is set in the INCAR. The total all-electron
+    charge density is the sum of both. These files are required for the Bader charge
+    partitioning scheme (Henkelman group).
+
+    Args:
+        working_directory (str): Path to the directory containing AECCAR0 and AECCAR2
 
     Returns:
-        tuple: The required charge densities
+        tuple:
+            VaspVolumetricData: Valence charge density (from AECCAR2)
+            VaspVolumetricData: Total all-electron charge density (AECCAR0 + AECCAR2)
     """
     cd_core = VaspVolumetricData()
     cd_total = VaspVolumetricData()

--- a/src/vaspparser/dft/waves/electronic.py
+++ b/src/vaspparser/dft/waves/electronic.py
@@ -458,7 +458,16 @@ class ElectronicStructure:
     def __getitem__(self, item):
         return self._output_dict[item]
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """
+        Serialize the electronic structure to a dictionary.
+
+        Returns:
+            dict: Dictionary with keys ``"TYPE"``, ``"k_points"``, ``"k_weights"``,
+                ``"eig_matrix"``, ``"occ_matrix"``, optionally ``"efermi"``,
+                ``"structure"``, and a ``"dos"`` sub-dictionary containing total and
+                resolved DOS data.
+        """
         h_es = {
             "TYPE": str(type(self)),
             "k_points": self.kpoint_list,
@@ -637,6 +646,7 @@ class Kpoint:
 
     @property
     def value(self):
+        """list/numpy.ndarray: The k-point coordinates in reciprocal space."""
         return self._value
 
     @value.setter
@@ -645,6 +655,7 @@ class Kpoint:
 
     @property
     def weight(self):
+        """float: The integration weight of this k-point (sum of all weights equals 1)."""
         return self._weight
 
     @weight.setter
@@ -669,6 +680,10 @@ class Kpoint:
 
     @property
     def eig_occ_matrix(self):
+        """
+        numpy.ndarray: Array of shape (n_spins, n_bands, 2) where the last axis holds
+        [eigenvalue, occupancy] for each band.
+        """
         eig_occ_list = []
         for bands in self.bands.values():
             eig_occ_list.append([[b.eigenvalue, b.occupancy] for b in bands])

--- a/src/vaspparser/vasp/output.py
+++ b/src/vaspparser/vasp/output.py
@@ -351,7 +351,23 @@ class Output:
             )
         self.generic_output.bands = self.electronic_structure
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """
+        Serialize the parsed VASP output into a nested dictionary.
+
+        The returned dictionary contains the following top-level keys (when available):
+
+        - ``"description"``: human-readable label for this output object
+        - ``"generic"``: positions, forces, cells, energies, and DFT-specific quantities
+        - ``"structure"``: final atomistic structure as a dictionary
+        - ``"electrostatic_potential"``: LOCPOT data (total and optional diff)
+        - ``"charge_density"``: CHGCAR data (total and optional spin diff)
+        - ``"electronic_structure"``: k-points, eigenvalues, occupancies, and DOS data
+        - ``"outcar"``: OUTCAR-specific quantities not available from vasprun.xml
+
+        Returns:
+            dict: Hierarchical dictionary of parsed VASP output
+        """
         output_dict = {
             "description": self.description,
             "generic": self.generic_output.to_dict(),
@@ -395,14 +411,26 @@ class GenericOutput:
         self._bands = ElectronicStructure()
 
     @property
-    def bands(self):
+    def bands(self) -> ElectronicStructure:
+        """ElectronicStructure: The electronic band structure object."""
         return self._bands
 
     @bands.setter
-    def bands(self, val):
+    def bands(self, val: ElectronicStructure):
         self._bands = val
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """
+        Serialize the generic and DFT-specific output into a dictionary.
+
+        The returned dictionary merges ``log_dict`` (generic quantities such as forces,
+        positions, energies, cells) with a ``"dft"`` sub-dictionary containing
+        DFT-specific quantities (magnetization, Fermi level lists, SCF energies, etc.)
+        and optionally a ``"bands"`` key with the electronic structure.
+
+        Returns:
+            dict: Dictionary of all generic and DFT output quantities
+        """
         go_dict, dft_dict = {}, {}
         for key, val in self.log_dict.items():
             go_dict[key] = val
@@ -415,6 +443,8 @@ class GenericOutput:
 
 
 class VaspCollectError(ValueError):
+    """Raised when VASP output files are present but cannot be parsed correctly."""
+
     pass
 
 
@@ -428,15 +458,33 @@ def parse_vasp_output(
     output_parser_class=Output,
 ) -> dict:
     """
-    Parse the VASP output in the working_directory and return it as hierachical dictionary.
+    Parse the VASP output in the working_directory and return it as a hierarchical dictionary.
+
+    This is the primary entry point for parsing a finished VASP calculation. The function
+    reads vasprun.xml (preferred) and/or OUTCAR, OSZICAR, LOCPOT, CHGCAR, PROCAR, and
+    CONTCAR/POSCAR files as available. If both vasprun.xml and OUTCAR are present, vasprun.xml
+    is used for energies, forces, positions, and electronic structure, while unique OUTCAR
+    quantities (stresses, elastic constants, Broyden mixing mesh, etc.) supplement the result.
+    Bader charge analysis is performed automatically when AECCAR0 and AECCAR2 are present.
 
     Args:
-        working_directory (str): directory of the VASP calculation
-        structure (Atoms): atomistic structure as optional input for matching the output to the input of the calculation
-        sorted_indices (list): list of indices used to sort the atomistic structure
+        working_directory (str): Path to the directory containing the VASP output files
+        structure (Atoms): Input atomistic structure. If None, it is read from CONTCAR/POSCAR.
+        sorted_indices (list/numpy.ndarray): Permutation indices mapping VASP atom order
+            (grouped by species) to the order in ``structure``. Computed automatically if None.
+        read_atoms_funct (callable): Function used to read structure files; defaults to
+            ``read_atoms`` which parses POSCAR/CONTCAR format.
+        es_class: Class used to store electronic structure data; defaults to
+            ``ElectronicStructure``.
+        bader_class: Class used for Bader charge analysis; defaults to ``Bader``.
+        output_parser_class: Class used to aggregate all output; defaults to ``Output``.
 
     Returns:
-        dict: hierarchical output dictionary
+        dict: Hierarchical output dictionary as returned by ``Output.to_dict()``.
+
+    Raises:
+        VaspCollectError: If required output files are found but cannot be parsed.
+        OSError: If no OUTCAR or vasprun.xml is present in working_directory.
     """
     output_parser = output_parser_class()
     if structure is None or len(structure) == 0:
@@ -508,13 +556,27 @@ def get_final_structure_from_file(
     read_atoms_funct: Callable = read_atoms,
 ) -> Atoms:
     """
-    Get the final structure of the simulation usually from the CONTCAR file
+    Read the final structure from a POSCAR-format file (typically CONTCAR).
+
+    The CONTCAR file written by VASP at the end of a relaxation or MD run contains the
+    final ionic positions, cell vectors, and optionally predictor-corrector velocities.
+    If ``structure`` is provided, its atom ordering is preserved and only the cell and
+    positions are updated; otherwise the structure is read entirely from the file.
 
     Args:
-        filename (str): Path to the CONTCAR file in VASP
+        working_directory (str): Path to the directory containing the structure file
+        filename (str): Name of the structure file to read (default: ``"CONTCAR"``)
+        structure (Atoms): Reference input structure used to set the species list and
+            atom ordering. If None, species are read directly from the file.
+        sorted_indices (list/numpy.ndarray): Permutation indices mapping the VASP atom
+            order to the order in ``structure``. Computed from ``structure`` if None.
+        read_atoms_funct (callable): Function for parsing POSCAR-format files
 
     Returns:
-        pyiron.atomistics.structure.atoms.Atoms: The final structure
+        ase.atoms.Atoms: The final structure with updated positions and cell
+
+    Raises:
+        OSError: If the file cannot be read or the positions are inconsistent
     """
     filename = posixpath.join(working_directory, filename)
     if structure is not None and sorted_indices is None:

--- a/src/vaspparser/vasp/parser/oszicar.py
+++ b/src/vaspparser/vasp/parser/oszicar.py
@@ -32,12 +32,35 @@ class Oszicar:
         self.parse_dict: Dict[str, np.ndarray] = dict()
 
     def from_file(self, filename: str = "OSZICAR") -> None:
+        """
+        Parse and store relevant quantities from the OSZICAR file into parse_dict.
+
+        The OSZICAR file written by VASP contains the convergence information for each
+        electronic and ionic step. This method extracts the free energy (F) printed at
+        the end of each ionic step.
+
+        Args:
+            filename (str): Path to the OSZICAR file to parse
+        """
         with open(filename, "r", errors="ignore") as f:
             lines = f.readlines()
         self.parse_dict["energy_pot"] = self.get_energy_pot(lines)
 
     @staticmethod
     def get_energy_pot(lines: List[str]) -> np.ndarray:
+        """
+        Extract the free energy F at the end of each ionic step from OSZICAR lines.
+
+        The OSZICAR file lists the free energy (F=) printed after each ionic step's SCF
+        convergence. This value corresponds to the free energy printed in the OUTCAR as
+        ``FREE ENERGIE OF THE ION-ELECTRON SYSTEM``.
+
+        Args:
+            lines (list): Lines read from the OSZICAR file
+
+        Returns:
+            numpy.ndarray: Array of free energies (eV) for each ionic step
+        """
         trigger = "F="
         energy_list = []
         for i, line in enumerate(lines):

--- a/src/vaspparser/vasp/parser/outcar.py
+++ b/src/vaspparser/vasp/parser/outcar.py
@@ -139,6 +139,16 @@ class Outcar:
             self.parse_dict["pressures"] = np.zeros(len(steps))
 
     def to_dict_minimal(self) -> dict:
+        """
+        Return a dictionary containing only the OUTCAR-specific quantities not available
+        from vasprun.xml. This is used when both output files are present to avoid
+        duplication.
+
+        Returns:
+            dict: Dictionary with keys: ``kin_energy_error``, ``broyden_mixing``,
+                  ``stresses``, ``irreducible_kpoints``, ``irreducible_kpoint_weights``,
+                  ``number_plane_waves``, ``energy_components``, ``resources``.
+        """
         output_dict = {}
         unique_quantities = [
             "kin_energy_error",
@@ -157,7 +167,17 @@ class Outcar:
 
     def get_vasp_version(
         self, filename: str = "OUTCAR", lines: Optional[list[str]] = None
-    ):
+    ) -> str:
+        """
+        Read the VASP version string from the first line of the OUTCAR file.
+
+        Args:
+            filename (str): Filename of the OUTCAR file to parse
+            lines (list/None): Lines already read from the file
+
+        Returns:
+            str: VASP version string (e.g. ``"vasp.6.3.2"`` or ``"vasp.5.4.4"``)
+        """
         lines = _get_lines_from_file(filename=filename, lines=lines)
         return lines[0].lstrip().split(sep=" ")[0]
 
@@ -446,16 +466,20 @@ class Outcar:
         filename: str = "OUTCAR", lines: Optional[list[str]] = None
     ) -> np.ndarray:
         """
-        Gets the total energy for every ionic step from the OUTCAR file
+        Gets the energy without entropy (E_wo_entrp) for every ionic step from the OUTCAR file.
+
+        This corresponds to the ``energy without entropy`` value printed by VASP in the
+        ``FREE ENERGIE OF THE ION-ELECTRON SYSTEM`` block and is equivalent to the
+        ``e_wo_entrp`` tag in vasprun.xml. It equals E_free + T*S, i.e. the total energy
+        before subtracting the electronic entropy contribution.
 
         Args:
             filename (str): Filename of the OUTCAR file to parse
             lines (list/None): lines read from the file
 
         Returns:
-            numpy.ndarray: A 1xM array of the total energies in $eV$
-
-            where M is the number of time steps
+            numpy.ndarray: A 1xM array of the energies without entropy in eV,
+            where M is the number of ionic steps
         """
 
         def get_energy_without_entropy_from_line(line):
@@ -478,16 +502,20 @@ class Outcar:
         filename: str = "OUTCAR", lines: Optional[list[str]] = None
     ) -> np.ndarray:
         """
-        Gets the total energy for every ionic step from the OUTCAR file
+        Gets the energy extrapolated to sigma->0 for every ionic step from the OUTCAR file.
+
+        VASP prints an extrapolated energy ``energy(sigma->0)`` which removes the
+        broadening-dependent entropy contribution. This is useful for comparing energies
+        computed with finite electronic temperature (ISMEAR, SIGMA) as it approximates
+        the T=0 energy. Corresponds to ``e_0_energy`` in vasprun.xml.
 
         Args:
             filename (str): Filename of the OUTCAR file to parse
             lines (list/None): lines read from the file
 
         Returns:
-            numpy.ndarray: A 1xM array of the total energies in $eV$
-
-            where M is the number of time steps
+            numpy.ndarray: A 1xM array of the sigma->0 extrapolated energies in eV,
+            where M is the number of ionic steps
         """
 
         def get_energy_sigma_0_from_line(line):
@@ -507,16 +535,19 @@ class Outcar:
         filename: str = "OUTCAR", lines: Optional[list[str]] = None
     ) -> np.ndarray:
         """
-        Gets the ediel_sol for every ionic step from the OUTCAR file
+        Gets the dielectric solvation energy (Ediel_sol) for every ionic step from the OUTCAR file.
+
+        This energy is only present when an implicit solvation model is used (e.g. with the
+        VASPsol or VASP built-in solvation via ``LSOL = .TRUE.``). It represents the
+        electrostatic interaction energy between the solute and the implicit solvent.
 
         Args:
             filename (str): Filename of the OUTCAR file to parse
             lines (list/None): lines read from the file
 
         Returns:
-            numpy.ndarray: A 1xM array of the total energies in $eV$
-
-            where M is the number of time steps
+            numpy.ndarray: A 1xM array of the solvation energies in eV,
+            where M is the number of ionic steps
         """
 
         def get_ediel_sol_from_line(line):
@@ -1015,6 +1046,23 @@ class Outcar:
     def get_band_properties(
         filename: str = "OUTCAR", lines: Optional[list[str]] = None
     ):
+        """
+        Extract the Fermi level, valence band maximum (VBM) and conduction band minimum (CBM)
+        at every ionic step from the OUTCAR file.
+
+        The values are derived from the ``band No.  band energies  occupation`` tables
+        printed in the OUTCAR after each self-consistent cycle.
+
+        Args:
+            filename (str): Filename of the OUTCAR file to parse
+            lines (list/None): Lines already read from the file
+
+        Returns:
+            tuple:
+                numpy.ndarray: Fermi levels (eV) for each ionic step
+                numpy.ndarray: VBM values (eV), shape (n_spins, n_ionic_steps)
+                numpy.ndarray: CBM values (eV), shape (n_spins, n_ionic_steps)
+        """
         fermi_trigger = "E-fermi"
         fermi_trigger_indices, lines = _get_trigger(
             lines=lines, filename=filename, trigger=fermi_trigger
@@ -1099,6 +1147,21 @@ class Outcar:
     def get_elastic_constants(
         filename: str = "OUTCAR", lines: Optional[list[str]] = None
     ):
+        """
+        Read the elastic stiffness tensor from the OUTCAR file.
+
+        The elastic constants are computed by VASP when ``IBRION=6`` is set in the INCAR.
+        VASP prints the full 6x6 Voigt-notation elastic moduli matrix under the heading
+        ``TOTAL ELASTIC MODULI (kBar)``; this method converts those values to GPa.
+
+        Args:
+            filename (str): Filename of the OUTCAR file to parse
+            lines (list/None): Lines already read from the file
+
+        Returns:
+            numpy.ndarray or None: A 6x6 array of elastic constants in GPa in Voigt notation
+            (order: xx, yy, zz, xy, yz, xz), or None if no elastic constants are found.
+        """
         lines = _get_lines_from_file(filename=filename, lines=lines)
         trigger_indices = _get_trigger(
             lines=lines,

--- a/src/vaspparser/vasp/procar.py
+++ b/src/vaspparser/vasp/procar.py
@@ -29,7 +29,22 @@ class Procar:
         self._is_spin_polarized = False
         self.dos_dict = OrderedDict()
 
-    def from_file(self, filename: str):
+    def from_file(self, filename: str) -> ElectronicStructure:
+        """
+        Parse a VASP PROCAR file and return the electronic structure.
+
+        The PROCAR file is written when ``LORBIT = 10`` or ``LORBIT = 11`` is set in the
+        INCAR. It contains the k-point coordinates and weights, band eigenvalues and
+        occupancies, and the projection of the wave functions onto spherical harmonics
+        centered on each ion (orbital- and atom-resolved DOS weights).
+
+        Args:
+            filename (str): Path to the PROCAR file
+
+        Returns:
+            ElectronicStructure: Populated electronic structure object with k-points,
+                bands, eigenvalues, occupancies, and atom/orbital-resolved DOS matrices
+        """
         with open(filename, errors="ignore") as f:
             es_obj = ElectronicStructure()
             lines = f.readlines()
@@ -64,12 +79,30 @@ class Procar:
 
     @staticmethod
     def _check_if_spin_polarized(line: str) -> Optional[bool]:
+        """
+        Check whether a PROCAR line indicates a spin-polarized calculation.
+
+        Args:
+            line (str): A line from the PROCAR file
+
+        Returns:
+            bool or None: True if the line contains a spin-component marker, else None
+        """
         if "spin component" in line.lower():
             return True
         return None
 
     @staticmethod
-    def _get_details(line):
+    def _get_details(line: str):
+        """
+        Parse the header line of a PROCAR file to get the number of k-points, bands and atoms.
+
+        Args:
+            line (str): The header line containing ``# of k-points: N  # of bands: M  # of ions: K``
+
+        Returns:
+            tuple: (num_kpts, num_bands, num_atoms) as integers
+        """
         lst = line.split()
         num_kpts = int(lst[3])
         num_bands = int(lst[7])
@@ -78,6 +111,17 @@ class Procar:
 
     @staticmethod
     def _get_kpoint_details(line: str):
+        """
+        Parse a k-point header line from the PROCAR file.
+
+        Args:
+            line (str): A line of the form ``k-point N :  kx ky kz  weight= w``
+
+        Returns:
+            tuple:
+                list: k-point coordinates [kx, ky, kz] in reciprocal coordinates
+                float: weight of the k-point
+        """
         line = line.replace("-", " -")
         lst = line.split()
         kpt = [float(lst[i]) for i in range(4, 7)]
@@ -86,6 +130,17 @@ class Procar:
 
     @staticmethod
     def _get_band_details(line: str):
+        """
+        Parse a band header line from the PROCAR file.
+
+        Args:
+            line (str): A line of the form ``band N # energy E # occ. O``
+
+        Returns:
+            tuple:
+                float: eigenvalue (eV)
+                float: occupancy
+        """
         lst = line.split()
         eigval = float(lst[4])
         occ = float(lst[7])
@@ -93,6 +148,24 @@ class Procar:
 
     @staticmethod
     def _get_dos_matrix(lines: list[str]):
+        """
+        Parse the atom-orbital projection block for a single band from the PROCAR file.
+
+        Each band block in the PROCAR lists the wavefunction projection onto spherical
+        harmonics for each ion, followed by a ``tot`` line with orbital sums and an overall
+        total. This method extracts the per-atom per-orbital matrix, the orbital-resolved
+        totals, and the atom-resolved totals.
+
+        Args:
+            lines (list): Lines of the projection block for a single band,
+                including the header and the ``tot`` summary line
+
+        Returns:
+            tuple:
+                numpy.ndarray: Shape (n_atoms, n_orbitals) - per-atom, per-orbital projections
+                numpy.ndarray: Shape (n_orbitals,) - sum over atoms for each orbital
+                numpy.ndarray: Shape (n_atoms,) - sum over orbitals for each atom
+        """
         num_orbitals = len((lines[0].strip()).split()) - 2
         num_atoms = len(lines) - 2
         dos_matrix = np.zeros((num_atoms, num_orbitals))

--- a/src/vaspparser/vasp/structure.py
+++ b/src/vaspparser/vasp/structure.py
@@ -137,6 +137,22 @@ def write_poscar(
 def get_poscar_content(
     structure: Atoms, write_species: bool = True, cartesian: bool = True
 ) -> List[str]:
+    """
+    Generate the lines of a POSCAR-format file from a structure object.
+
+    Atoms are written grouped by species (alphabetical order) as required by VASP.
+    If the structure has ``FixCartesian`` constraints, the file is written in Direct
+    (fractional) coordinates with a ``Selective dynamics`` block.
+
+    Args:
+        structure (ase.atoms.Atoms): The structure to write
+        write_species (bool): If True, include the species line (VASP5+ format)
+        cartesian (bool): If True, write Cartesian coordinates; otherwise Direct.
+            Overridden to False when selective dynamics are present.
+
+    Returns:
+        list: Lines of the POSCAR file as strings (each ending with ``\\n``)
+    """
     endline = "\n"
     selec_dyn = False
     line_lst = [

--- a/src/vaspparser/vasp/vasprun.py
+++ b/src/vaspparser/vasp/vasprun.py
@@ -64,7 +64,16 @@ class Vasprun:
 
     def parse_root_to_dict(self, filename: str):
         """
-        Parses from the main xml root.
+        Parse the vasprun.xml file and populate ``vasprun_dict`` with all data.
+
+        This method iterates over the XML tree using ``iterparse`` and dispatches
+        each recognized top-level element (generator, incar, kpoints, atominfo,
+        structure, calculation, parameters) to the appropriate sub-parser. After
+        parsing, positions are converted to fractional coordinates if they appear
+        to be in Cartesian, and all lists are converted to numpy arrays.
+
+        Args:
+            filename (str): Path to the vasprun.xml file
         """
         d = self.vasprun_dict
         d["scf_energies"] = []
@@ -464,7 +473,14 @@ class Vasprun:
         d["scf_dipole_moments"].append(scf_moments)
 
     @staticmethod
-    def parse_cce_to_dict(node, d):
+    def parse_cce_to_dict(node, d: dict):
+        """
+        Parse constrained-charge-equilibration (CCE) output from a vasprun.xml node.
+
+        Args:
+            node (xml.etree.Element): The CCE node to parse
+            d (dict): Dictionary to which the parsed values are appended
+        """
         for item in node:
             if item.attrib["name"] not in list(d.keys()):
                 d[item.attrib["name"]] = []
@@ -741,10 +757,18 @@ class Vasprun:
 
     def get_electronic_structure(self, es_class=ElectronicStructure):
         """
-        Get's the electronic structure from the VASP calculation
+        Construct an ElectronicStructure object from the parsed vasprun.xml data.
+
+        Transfers k-point list, k-point weights, eigenvalue matrix, occupancy matrix,
+        Fermi level, total DOS (if available), atom-resolved DOS (if LORBIT >= 10),
+        and projected DOS (if LORBIT = 11) into the returned object.
+
+        Args:
+            es_class: Class to instantiate for the electronic structure; defaults to
+                ``ElectronicStructure``.
 
         Returns:
-            pyiron.atomistics.waves.electronic.ElectronicStructure: The electronic structure object
+            ElectronicStructure: Populated electronic structure object
 
         """
         es_obj = es_class()

--- a/src/vaspparser/vasp/volumetric_data.py
+++ b/src/vaspparser/vasp/volumetric_data.py
@@ -290,6 +290,14 @@ class VaspVolumetricData(VolumetricData):
         self._diff_data = val
 
     def to_dict(self) -> dict:
+        """
+        Serialize the volumetric data into a dictionary.
+
+        Returns:
+            dict: Dictionary with keys ``"TYPE"`` (class name string), ``"total"``
+                (3D numpy array of total volumetric data), and optionally ``"diff"``
+                (3D numpy array of spin-difference data for CHGCAR spin-polarized runs).
+        """
         volumetric_data_dict = {
             "TYPE": str(type(self)),
             "total": self.total_data,


### PR DESCRIPTION
Add missing docstrings and extend existing ones throughout the package so that VASP-familiar users can understand each function's purpose, the VASP tags and files involved, and the units and shape of all returned values.

Changes by file:
- oszicar.py: from_file, get_energy_pot
- outcar.py: to_dict_minimal, get_vasp_version, get_band_properties, get_elastic_constants; clarify get_energy_without_entropy (E_wo_entrp), get_energy_sigma_0 (extrapolated T=0 energy), get_ediel_sol (solvation)
- output.py: Output.to_dict, GenericOutput.bands/to_dict, VaspCollectError; extend parse_vasp_output and get_final_structure_from_file
- procar.py: from_file, _check_if_spin_polarized, _get_details, _get_kpoint_details, _get_band_details, _get_dos_matrix
- structure.py: get_poscar_content
- vasprun.py: parse_root_to_dict, get_electronic_structure, parse_cce_to_dict
- bader.py: fix __init__ args, _create_cube_files, get_valence_and_total_charge_density
- volumetric_data.py: to_dict
- electronic.py: to_dict, Kpoint.value/weight/eig_occ_matrix