### PR TITLE
Extend unit test coverage and fix two electronic-structure bugs

### DIFF
--- a/src/vaspparser/dft/waves/dos.py
+++ b/src/vaspparser/dft/waves/dos.py
@@ -97,7 +97,9 @@ class Dos:
         for spin in range(len(self.energies)):
             for key, val in self.orbital_dict.items():
                 r_dos = self.get_orbital_resolved_dos(val)
-                plt.plot(self.energies, r_dos, label=key + f"spin {spin}", **kwargs)
+                plt.plot(
+                    self.energies[spin], r_dos, label=key + f"spin {spin}", **kwargs
+                )
         plot.legend()
         return plot
 

--- a/src/vaspparser/dft/waves/electronic.py
+++ b/src/vaspparser/dft/waves/electronic.py
@@ -435,14 +435,14 @@ class ElectronicStructure:
             dimension = (
                 self.n_spins,
                 len(self.kpoints),
-                len(self.kpoints[0].bands),
+                len(self.kpoints[0].bands[0]),
                 n_atoms,
                 n_orbitals,
             )
             self._grand_dos_matrix = np.zeros(dimension)
             for spin in range(self.n_spins):
                 for i, kpt in enumerate(self.kpoints):
-                    for j, band in enumerate(kpt.bands):
+                    for j, band in enumerate(kpt.bands[spin]):
                         self._grand_dos_matrix[spin, i, j, :, :] = (
                             band.resolved_dos_matrix
                         )

--- a/tests/unit/dft/test_volumetric.py
+++ b/tests/unit/dft/test_volumetric.py
@@ -98,6 +98,56 @@ class TestVolumetricData(unittest.TestCase):
         self.assertTrue(os.path.exists(filename))
         os.remove(filename)
 
+    def test_spherical_average_no_total_data(self):
+        self.vol_data.atoms = self.atoms
+        with self.assertRaises(ValueError):
+            self.vol_data.spherical_average_potential(
+                structure=self.atoms, spherical_center=[0.5, 0.5, 0.5]
+            )
+
+    def test_cylindrical_average_no_total_data(self):
+        self.vol_data.atoms = self.atoms
+        with self.assertRaises(ValueError):
+            self.vol_data.cylindrical_average_potential(
+                structure=self.atoms, spherical_center=[0.5, 0.5, 0.5], axis_of_cyl=2
+            )
+
+    def test_get_average_along_axis_no_total_data(self):
+        with self.assertRaises(ValueError):
+            self.vol_data.get_average_along_axis(ind=0)
+
+    def test_get_average_along_axis_ind_1_and_default(self):
+        self.vol_data.total_data = np.ones((10, 10, 10))
+        avg_1 = self.vol_data.get_average_along_axis(ind=1)
+        self.assertTrue(np.allclose(avg_1, np.ones(10)))
+        avg_default = self.vol_data.get_average_along_axis(ind=2)
+        self.assertTrue(np.allclose(avg_default, np.ones(10)))
+
+    def test_write_cube_file_no_total_data(self):
+        self.vol_data.atoms = self.atoms
+        with self.assertRaises(ValueError):
+            self.vol_data.write_cube_file("test.cube")
+
+    def test_write_vasp_volumetric_no_atoms(self):
+        self.vol_data.total_data = self.data
+        with self.assertRaises(ValueError):
+            self.vol_data.write_vasp_volumetric(filename="test_chgcar")
+
+    def test_write_vasp_volumetric_no_total_data(self):
+        self.vol_data.atoms = self.atoms
+        with self.assertRaises(ValueError):
+            self.vol_data.write_vasp_volumetric(filename="test_chgcar")
+
+    def test_dist_between_two_grid_points_cyl_directions_0_and_1(self):
+        dist_0 = self.vol_data.dist_between_two_grid_points_cyl(
+            [0, 0, 0], [1, 1, 1], np.eye(3), (10, 10, 10), 0
+        )
+        self.assertAlmostEqual(dist_0, np.sqrt(0.02))
+        dist_1 = self.vol_data.dist_between_two_grid_points_cyl(
+            [0, 0, 0], [1, 1, 1], np.eye(3), (10, 10, 10), 1
+        )
+        self.assertAlmostEqual(dist_1, np.sqrt(0.02))
+
     def test_read_cube_file_one_atom(self):
         atoms = Atoms("H", positions=[[0, 0, 0]], cell=np.eye(3))
         self.vol_data.atoms = atoms

--- a/tests/unit/dft/waves/test_more_dos.py
+++ b/tests/unit/dft/waves/test_more_dos.py
@@ -32,6 +32,15 @@ class TestMoreDos(unittest.TestCase):
         except Exception as e:
             self.fail(f"plot_total_dos raised an exception: {e}")
 
+    def test_plot_orbital_resolved_dos_success(self):
+        dos = Dos(es_obj=self.mock_es)
+        # mock grand_dos_matrix only has 4 orbitals, restrict orbital_dict to match
+        dos.orbital_dict = {"s": [0], "p": [1, 2, 3]}
+        try:
+            dos.plot_orbital_resolved_dos()
+        except Exception as e:
+            self.fail(f"plot_orbital_resolved_dos raised an exception: {e}")
+
     def test_plot_orbital_resolved_dos_no_resolved(self):
         self.mock_es.grand_dos_matrix = None
         dos = Dos(es_obj=self.mock_es)

--- a/tests/unit/dft/waves/test_more_electronic.py
+++ b/tests/unit/dft/waves/test_more_electronic.py
@@ -243,6 +243,28 @@ class TestMoreElectronicStructure(unittest.TestCase):
         self.es_obj.efermi = 0.0
         self.assertIn("Is a metal: False", str(self.es_obj))
 
+    def test_eg_vbm_cbm_setters(self):
+        self.es_obj.eg = [1.5]
+        self.assertEqual(self.es_obj._eg, [1.5])
+        self.es_obj.vbm = [-2.0]
+        self.assertEqual(self.es_obj._vbm, [-2.0])
+        self.es_obj.cbm = [3.0]
+        self.assertEqual(self.es_obj._cbm, [3.0])
+
+    def test_grand_dos_matrix_lazy_build(self):
+        self.es_obj.add_kpoint(value=[0, 0, 0], weight=1)
+        self.es_obj.kpoints[0].add_band(eigenvalue=-1.0, occupancy=1.0, spin=0)
+        self.es_obj.kpoints[0].bands[0][0].resolved_dos_matrix = np.ones((2, 3))
+        grand_dos_matrix = self.es_obj.grand_dos_matrix
+        self.assertEqual(grand_dos_matrix.shape, (1, 1, 1, 2, 3))
+        self.assertTrue(np.array_equal(grand_dos_matrix[0, 0, 0], np.ones((2, 3))))
+
+    def test_get_spin_resolved_dos_success(self):
+        self.es_obj.dos_energies = np.array([1, 2, 3])
+        self.es_obj.dos_densities = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        rdos = self.es_obj.get_spin_resolved_dos(spin_indices=1)
+        self.assertTrue(np.array_equal(rdos, np.array([0.4, 0.5, 0.6])))
+
     def test_kpoint_eig_occ_matrix(self):
         kpt = Kpoint()
         kpt.add_band(eigenvalue=-1.0, occupancy=1.0, spin=0)

--- a/tests/unit/vasp/test_procar.py
+++ b/tests/unit/vasp/test_procar.py
@@ -16,6 +16,10 @@ class TestProcarParser(unittest.TestCase):
             "../../static/vasp_test_files/PROCAR_for_test",
         )
 
+    def test_check_if_spin_polarized(self):
+        self.assertIsNone(self.parser._check_if_spin_polarized("dummy"))
+        self.assertTrue(self.parser._check_if_spin_polarized("spin component 1"))
+
     def test_from_file(self):
         self.assertIsNone(self.parser._check_if_spin_polarized("dummy"))
         es_obj = self.parser.from_file(self.file_path)

--- a/tests/unit/vasp/test_structure.py
+++ b/tests/unit/vasp/test_structure.py
@@ -8,13 +8,16 @@ import posixpath
 import numpy as np
 
 from ase.atoms import Atoms
-from ase.constraints import FixCartesian
+from ase.constraints import FixAtoms, FixCartesian
 from vaspparser.vasp.structure import (
     read_atoms,
     write_poscar,
     vasp_sorter,
     atoms_from_string,
     manip_contcar,
+    get_poscar_content,
+    get_species_list_from_potcar,
+    _dict_to_atoms,
 )
 import warnings
 
@@ -251,6 +254,98 @@ class TestVaspStructure(unittest.TestCase):
         self.assertEqual(new_struct.positions[new_struct.symbols.indices()["O"], 2], 8)
         os.remove("simple_water")
         os.remove("simple_water_new")
+
+    def test_get_species_list_from_potcar(self):
+        potcar_file = os.path.join(
+            self.file_location,
+            "../../static/vasp_test_files/full_job_sample/POTCAR",
+        )
+        species_list = get_species_list_from_potcar(potcar_file)
+        self.assertEqual(species_list, ["Fe"])
+
+    def test_read_atoms_species_from_potcar_empty(self):
+        poscar_path = posixpath.join(self.file_location, "POSCAR_potcar_test")
+        with open(poscar_path, "w") as f:
+            f.write(
+                "Fe\n1.0\n10.0 0.0 0.0\n0.0 10.0 0.0\n0.0 0.0 10.0\n1\n"
+                "Direct\n0.0 0.0 0.0\n"
+            )
+        potcar_path = posixpath.join(self.file_location, "POTCAR")
+        with open(potcar_path, "w") as f:
+            f.write("This POTCAR has no VRHFIN entry\n")
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                atoms = read_atoms(filename=poscar_path, species_from_potcar=True)
+                self.assertEqual(len(atoms), 1)
+                self.assertTrue(
+                    any(
+                        "Unable to read species information from POTCAR"
+                        in str(warn.message)
+                        for warn in w
+                    )
+                )
+        finally:
+            os.remove(poscar_path)
+            os.remove(potcar_path)
+
+    def test_get_poscar_content_unsupported_constraint(self):
+        struct = self.structure.copy()
+        struct.constraints = [FixAtoms(indices=[0])]
+        with self.assertRaises(ValueError):
+            get_poscar_content(structure=struct)
+
+    def test_atoms_from_string_all_selective_dynamics_combinations(self):
+        lines = [
+            "Fe",
+            "1.0",
+            "10.0 0.0 0.0",
+            "0.0 10.0 0.0",
+            "0.0 0.0 10.0",
+            "8",
+            "Selective dynamics",
+            "Direct",
+            "0.0 0.0 0.0 T T T",
+            "0.1 0.1 0.1 T T F",
+            "0.2 0.2 0.2 T F T",
+            "0.3 0.3 0.3 T F F",
+            "0.4 0.4 0.4 F T T",
+            "0.5 0.5 0.5 F T F",
+            "0.6 0.6 0.6 F F T",
+            "0.7 0.7 0.7 F F F",
+        ]
+        atoms = atoms_from_string(lines)
+        self.assertEqual(len(atoms), 8)
+        self.assertEqual(len(atoms.constraints), 8)
+
+    def test_dict_to_atoms_species_list_index_error(self):
+        from collections import OrderedDict
+
+        atoms_dict = {
+            "relative": True,
+            "positions": np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]]),
+            "cell": 10.0 * np.eye(3),
+            "species_dict": OrderedDict(
+                [("species_0", {"count": 1}), ("species_1", {"count": 1})]
+            ),
+        }
+        with self.assertRaises(ValueError):
+            _dict_to_atoms(atoms_dict, species_list=["Fe"])
+
+    def test_dict_to_atoms_first_line_assertion_error(self):
+        lines = [
+            "H",
+            "1.0",
+            "10.0 0.0 0.0",
+            "0.0 10.0 0.0",
+            "0.0 0.0 10.0",
+            "1 1",
+            "Direct",
+            "0.0 0.0 0.0",
+            "0.5 0.5 0.5",
+        ]
+        with self.assertRaises(AssertionError):
+            atoms_from_string(lines)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
## Summary
- Extends unit test coverage for `vasp/structure.py`, `vasp/procar.py`, `dft/volumetric.py`, `dft/waves/electronic.py`, and `dft/waves/dos.py`, raising overall coverage from 93% to 95% (structure.py, procar.py, and volumetric.py now sit at 99-100%).
- While writing tests for the `grand_dos_matrix` lazy-build path and `plot_orbital_resolved_dos`, found and fixed two real bugs:
  - `ElectronicStructure.grand_dos_matrix` iterated over `Kpoint.bands` (a dict keyed by spin) instead of `Kpoint.bands[spin]`, so it crashed (`AttributeError: 'int' object has no attribute 'resolved_dos_matrix'`) whenever the lazy build was triggered — this is reachable in practice via `Output.collect()` when a PROCAR file is present. The band-count dimension also used the spin-dict length instead of the per-spin band count.
  - `Dos.plot_orbital_resolved_dos` passed the full per-spin `self.energies` list to `plt.plot` instead of indexing it by spin, so any call crashed with a matplotlib shape-mismatch error.

## Test plan
- [x] `python -m pytest tests/unit -q` — 157 passed (up from 138)
- [x] `python -m pytest tests/unit --cov=vaspparser --cov-report=term-missing` — overall coverage 93% → 95%
- [x] `python -m black --check` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)