### PR TITLE
Add Pullay stress parser for OUTCAR files

### DIFF
--- a/src/vaspparser/vasp/parser/outcar.py
+++ b/src/vaspparser/vasp/parser/outcar.py
@@ -64,6 +64,7 @@ class Outcar:
         cells = self.get_cells(filename=filename, lines=lines)
         steps = self.get_steps(filename=filename, lines=lines)
         temperatures = self.get_temperatures(filename=filename, lines=lines)
+        pullay_stress = self.get_pullay_stress(filename=filename, lines=lines)
         time = self.get_time(filename=filename, lines=lines)
         fermi_level = self.get_fermi_level(filename=filename, lines=lines)
         scf_moments = self.get_dipole_moments(filename=filename, lines=lines)
@@ -107,6 +108,7 @@ class Outcar:
         self.parse_dict["cells"] = cells
         self.parse_dict["steps"] = steps
         self.parse_dict["temperatures"] = temperatures
+        self.parse_dict["pullay_stress"] = pullay_stress
         self.parse_dict["time"] = time
         self.parse_dict["fermi_level"] = fermi_level
         self.parse_dict["scf_dipole_moments"] = scf_moments
@@ -147,7 +149,8 @@ class Outcar:
         Returns:
             dict: Dictionary with keys: ``kin_energy_error``, ``broyden_mixing``,
                   ``stresses``, ``irreducible_kpoints``, ``irreducible_kpoint_weights``,
-                  ``number_plane_waves``, ``energy_components``, ``resources``.
+                  ``number_plane_waves``, ``energy_components``, ``resources``,
+                  ``pullay_stress``.
         """
         output_dict = {}
         unique_quantities = [
@@ -159,6 +162,7 @@ class Outcar:
             "number_plane_waves",
             "energy_components",
             "resources",
+            "pullay_stress",
         ]
         for key in self.parse_dict:
             if key in unique_quantities:
@@ -717,6 +721,28 @@ class Outcar:
             r"[a-zA-Z]", r"", line_ngx.replace(" ", "").replace("\n", "")
         ).split("=")
         return np.prod([int(val) for val in str_list[1:]])
+
+    @staticmethod
+    def get_pullay_stress(filename: str = "OUTCAR", lines: Optional[list[str]] = None):
+        """
+        Gets the Pullay stress for every ionic step from the OUTCAR file
+
+        Args:
+            filename (str): Filename of the OUTCAR file to parse
+            lines (list/None): lines read from the file
+
+        Returns:
+            numpy.ndarray: An array of Pullay stress values in kB
+
+            where the length of the array equals the number of ionic steps
+        """
+        trigger = "Pullay stress ="
+        trigger_indices, lines = _get_trigger(
+            lines=lines, filename=filename, trigger=trigger
+        )
+        return np.array(
+            [float(lines[j].split(trigger)[-1].split()[0]) for j in trigger_indices]
+        )
 
     @staticmethod
     def get_temperatures(filename: str = "OUTCAR", lines: Optional[list[str]] = None):

--- a/tests/unit/vasp/test_outcar.py
+++ b/tests/unit/vasp/test_outcar.py
@@ -59,6 +59,7 @@ class TestOutcar(unittest.TestCase):
             type_dict["pressures"] = np.ndarray
             type_dict["energies_int"] = np.ndarray
             type_dict["energies_zero"] = np.ndarray
+            type_dict["pullay_stress"] = np.ndarray
             parse_keys = self.outcar_parser.parse_dict.keys()
             for key, value in type_dict.items():
                 self.assertTrue(key in parse_keys)
@@ -1686,6 +1687,22 @@ class TestOutcar(unittest.TestCase):
             if int(filename.split("/OUTCAR_")[-1]) in [1, 2, 3, 4, 5, 6]:
                 temperatures = np.array([0.0])
                 self.assertEqual(temperatures.__str__(), output.__str__())
+
+    def test_get_pullay_stress(self):
+        def naive_parse(filename):
+            with open(filename) as f:
+                values = []
+                for l in f:
+                    if "Pullay stress" in l:
+                        values.append(float(l.split("Pullay stress =")[-1].split()[0]))
+                return np.array(values)
+
+        for filename in self.file_list:
+            with self.subTest(filename=filename):
+                output = self.outcar_parser.get_pullay_stress(filename)
+                self.assertIsInstance(output, np.ndarray)
+                expected = naive_parse(filename)
+                np.testing.assert_array_equal(output, expected)
 
     def test_get_steps(self):
         def naive_parse(filename):

--- a/tests/unit/vasp/test_output.py
+++ b/tests/unit/vasp/test_output.py
@@ -52,6 +52,7 @@ class TestOutput(unittest.TestCase):
         self.assertIn("charge_density", output_dict)
         self.assertIn("electronic_structure", output_dict)
         self.assertIn("outcar", output_dict)
+        self.assertIn("pullay_stress", output_dict["outcar"])
 
     def test_parse_vasp_output(self):
         output_dict = parse_vasp_output(working_directory=self.full_job_sample_path)


### PR DESCRIPTION
## Summary
- Parse the `Pullay stress` value from each ionic step in the OUTCAR file (e.g. `external pressure =  -455.93 kB  Pullay stress =    0.00 kB`)
- Expose it as `parse_dict["pullay_stress"]` (numpy array, one value per ionic step, kB) in `Outcar`
- Surface it in `output_dict["outcar"]["pullay_stress"]` via `Outcar.to_dict_minimal()`

## Test plan
- [x] Added `test_get_pullay_stress` in `tests/unit/vasp/test_outcar.py`, validated against all `OUTCAR_*` static sample files (including `OUTCAR_9`, which has two ionic steps)
- [x] Extended `test_from_file` type check to cover the new `pullay_stress` key
- [x] Extended `test_to_dict` in `tests/unit/vasp/test_output.py` to assert `pullay_stress` is present in `output_dict["outcar"]`
- [x] Full test suite passes (`pytest tests/` — 158 passed)
- [x] `ruff format` / `ruff check --select I` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)